### PR TITLE
Removed the need for incl_block

### DIFF
--- a/plasma_cash/child_chain/child_chain.py
+++ b/plasma_cash/child_chain/child_chain.py
@@ -34,8 +34,8 @@ class ChildChain(object):
         # Currently, denomination is always 1. This may change in the future.
         denomination = event['args']['denomination']
         depositor = event['args']['from']
-        deposit_tx = Transaction(slot, 0, denomination, depositor,
-                                 incl_block=blknum)
+        deposit_tx = Transaction(slot, 0, denomination, depositor)
+
         # create a new plasma block on deposit
         deposit_block = Block([deposit_tx])
         self.blocks[blknum] = deposit_block

--- a/plasma_cash/child_chain/transaction.py
+++ b/plasma_cash/child_chain/transaction.py
@@ -18,10 +18,9 @@ class Transaction(rlp.Serializable):
     ]
 
     def __init__(self, uid, prev_block, denomination, new_owner,
-                 sig=b'\x00' * 65, incl_block=0):
+                 sig=b'\x00' * 65):
         self.uid = uid
         self.prev_block = prev_block
-        self.incl_block = incl_block
         self.denomination = denomination
         self.new_owner = ethereum.utils.normalize_address(new_owner)
         self.sig = sig
@@ -30,7 +29,7 @@ class Transaction(rlp.Serializable):
 
     @property
     def hash(self):
-        if self.incl_block % 1000 == 0:
+        if self.prev_block != 0:
             ret = w3.sha3(rlp.encode(self, UnsignedTransaction))
         else:
             ret = w3.soliditySha3(['uint64'], [self.uid])

--- a/plasma_cash/client/client.py
+++ b/plasma_cash/client/client.py
@@ -50,8 +50,7 @@ class Client(object):
 
             # prev_block = 0 , denomination = 1
             exiting_tx = Transaction(slot, 0, 1,
-                                     self.token_contract.account.address,
-                                     incl_block=tx_blk_num)
+                                     self.token_contract.account.address)
             exiting_tx.make_mutable()
             exiting_tx.sign(self.key)
             exiting_tx.make_immutable()
@@ -86,8 +85,7 @@ class Client(object):
 
             # prev_block = 0 , denomination = 1
             exiting_tx = Transaction(slot, 0, 1,
-                                     self.token_contract.account.address,
-                                     incl_block=tx_blk_num)
+                                     self.token_contract.account.address)
             exiting_tx.make_mutable()
             exiting_tx.sign(self.key)
             exiting_tx.make_immutable()
@@ -182,9 +180,7 @@ class Client(object):
 
     def send_transaction(self, slot, prev_block, denomination, new_owner):
         new_owner = utils.normalize_address(new_owner)
-        incl_block = self.get_block_number()
-        tx = Transaction(slot, prev_block, denomination, new_owner,
-                         incl_block=incl_block)
+        tx = Transaction(slot, prev_block, denomination, new_owner)
         tx.make_mutable()
         tx.sign(self.key)
         tx.make_immutable()


### PR DESCRIPTION
Deposit/normal txs are differentiated based on prev_block.

Previously we were including some target block in our transaction creation, which was used only to differentiate between deposit and non-deposit transactions. This was redundant, as just checking for if prev_block was 0 (i.e. the transaction was minted) is enough.