### PR TITLE
Stop when failure is encountered

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -euxo pipefail
+set -exo pipefail
 
 cd server
 npm install


### PR DESCRIPTION
Currently build will continue when lint fails. This will ensure Jenkins build fails when any command returns nonzero in the script.