### PR TITLE
[WIP] Plasma Debit - EXPERIMENTAL

### DIFF
--- a/server/PlasmaDebitNotes.md
+++ b/server/PlasmaDebitNotes.md
@@ -1,0 +1,116 @@
+# Plasma Debit
+
+Previously the denomination field in a transaction was always set to 1, because
+we were always transferring the whole coin. Now a UTXO off-chain will also have the denomination field set, to some number that must be less than the coin's . 
+
+Plasma Debit's assumption is that a coin can have any value between 0 and its
+initial deposit value. A 5/5 coin is owned by the user, a 3/5 coin allows the
+user to withdraw 3/5 and the 2/5 go to the operator, while a 0/5 coin is woned
+100% by the operator. 0/5 coins can be generated whne the operator makes a
+deposit and can be used to bootstrap channels between the operator and users,
+WITHOUT HAVING THE USERES TO MAKE DEPOSITS!
+
+There are 2 kinds of transactions: 
+- Ownership transfer transactions, which transfer the whole coin
+- Denomination change transactions, which just alter the balance of the coin
+  (which can be thought of paying fees to an operator)
+
+A transaction that changes the denominations of two coins must meet the
+following:
+- Coin slots must be different
+- Flow is always from address 1 to address 2 
+- Amount >0 indicates that address1's coin gets reduced by amount, and address
+  2's coin gets increased by the same amount, opposite applies for amount <0.
+
+- Whenever the `authority` address makes a deposit, a new coin is minted to
+  their address, as usual, however the coin's denomination is set to 0, to
+indicate that they own the whole coin. 
+
+When a coin is being exited, 
+
+# Providing liquidity to a coin!
+
+The operator can deposit into any coin from the main chain, which increments v
+but not a. So if Bob has a 5 ETH coin and a current balance of 5 ETH (i.e. v is
+5 and a is 5), then the operator can deposit 1 ETH into the coin, making it a 6
+ETH coin where Bob has a balance of 5 ETH (i.e. v is 6 and a is 5), which gives
+the operator an implied balance of 1 ETH.
+
+
+## Sending atomic transactions
+
+Ok, with proofs extended with these joint signatures, how can some other
+entity that is receiving a partially spent Plasma Debit coin know that it is
+receiving the highest nonce joint signature between the coinholder and the
+Plasma operator?
+
+Nope, because notarized transactions (those included in the Plasma Cash chain)
+take strict precedence over the intermediate payment-channel-like transactions. <-- OK?
+
+The transaction that transfers to Bob doesn’t have to mention or acknowledge
+any of the intermediate states between Alice and the operator, because those
+are all obsoleted as soon as the transfer to Bob is included on the Plasma Cash
+chain. 
+
+The transfer to Bob does have to state what the balance of the coin is
+that Bob receives, though. <-- BALANCE 
+
+Updates to the balance would not actually need to be included in the Plasma
+blocks, since they require only the mutual consent of the coinholder and
+operator. The exit game could be altered relatively easily to allow the
+operator and current coinholder to instantly update their balance by exchanging <-- NEED TO ADD EXTRA STUFF TO THE EXIT GAME + NONCES
+signatures on a state update (which would then be almost exactly equivalent to
+a payment channel). 
+
+> The only transactions that need to be notarized (i.e.
+included in Plasma blocks) are those that either change the owner of the
+channel, or involve multiple coins.
+
+No, because you could instead just have the operator and user both sign the new
+balance, along with an incrementing nonce representing which intermediate
+balance it was. 
+
+1) When withdrawing, the most recent committed Plasma Debit coin
+would take priority, 
+2) after that, the most recent (i.e. highest-nonce) set
+of balances that was signed by both the operator and user would take priority.
+This is the same basic mechanism as state channels.
+
+
+^ NEED A CHALLENGE FOR AN EXIT WHERE WE REVEAL A SPEND WITH A HIGHER NONCE
+
+
+
+## Liquidity Injections
+
+Have a staking contract that handles all liquuidity. users deposit funds to the
+contract in order to have a big reserve. We consider the liquidity reserve to
+be governed by the validators. If we have 10 eth inside it, any liquidity
+injection should be voted on. Plasma Cash/Deit withdrawals incur a X% fee. That
+fee is paid out to the staking contract after each withdrawal (maybe make it
+just an sstore and then make it a full withdrawal in contract terms - sounds
+better!). After fees have benen withdrawn from Plasma to the dao, the dao will
+give out the dividends. Users will get more fees based on the % of the coin
+that the liquidity was provided.
+
+T0 -> 30% 50% 20%, 10 coins
+T1000000 -> 100 coins 
+30%Plasma Cash/Deit withdrawals incur a X% fee. That fee is paid out to the
+staking contract after each withdrawal (maybe make it just an sstore and then
+make it a full withdrawal in contract terms - sounds better!). After fees have
+benen withdrawn from Plasma to the dao, the dao will give out the dividends.
+Users will get more fees based on the % of the coin that the liquidity was
+provided.
+
+T0 -> 30% 50% 20%, 10 coins, 3, 5, 2
+T100 -> 100 coins, 30, 50, 20
+
+1) U2 can withdraw up to STAKED/TOTAL = 50%
+2) U2 withdraws 20 coins, new balance is 30
+3) Reduce total stake by 20, new stake = 80
+4) Recalculate percentages: 30/80 30/80 20/80
+
+--
+
+U1 can now withdrawl up to 3/8 of new stake: 30 coins
+

--- a/server/contracts/Core/RootChain.sol
+++ b/server/contracts/Core/RootChain.sol
@@ -453,8 +453,9 @@ contract RootChain is ERC721Receiver, ERC20Receiver {
         bool hasChallenges = checkPendingChallenges(slot);
 
         if (!hasChallenges) {
-            // Update coin's owner
+            // Update coin's owner and balance
             coin.owner = coin.exit.owner;
+            coin.balance = coin.exit.balance;
             coin.state = State.EXITED;
 
             // Allow the exitor to withdraw their bond

--- a/server/contracts/Libraries/Transaction/Transaction.sol
+++ b/server/contracts/Libraries/Transaction/Transaction.sol
@@ -13,7 +13,7 @@ library Transaction {
         address owner;
         bytes32 hash;
         uint256 prevBlock;
-        uint256 denomination; 
+        uint256 balance;
     }
 
     function getTx(bytes memory txBytes) internal pure returns (TX memory) {
@@ -22,7 +22,7 @@ library Transaction {
 
         transaction.slot = uint64(rlpTx[0].toUint());
         transaction.prevBlock = rlpTx[1].toUint();
-        transaction.denomination = rlpTx[2].toUint();
+        transaction.balance = rlpTx[2].toUint();
         transaction.owner = rlpTx[3].toAddress();
         if (transaction.prevBlock == 0) { // deposit transaction
             transaction.hash = keccak256(abi.encodePacked(transaction.slot));
@@ -42,6 +42,11 @@ library Transaction {
         } else {
             hash = keccak256(txBytes);
         }
+    }
+
+    function getBalance(bytes memory txBytes) internal pure returns (uint256 balance) {
+        RLP.RLPItem[] memory rlpTx = txBytes.toRLPItem().toList(4);
+        balance = rlpTx[2].toUint();
     }
 
     function getOwner(bytes memory txBytes) internal pure returns (address owner) {

--- a/server/contracts/Libraries/Transaction/Transaction.sol
+++ b/server/contracts/Libraries/Transaction/Transaction.sol
@@ -13,17 +13,19 @@ library Transaction {
         address owner;
         bytes32 hash;
         uint256 prevBlock;
+        uint256 nonce;
         uint256 balance;
     }
 
     function getTx(bytes memory txBytes) internal pure returns (TX memory) {
-        RLP.RLPItem[] memory rlpTx = txBytes.toRLPItem().toList(4);
+        RLP.RLPItem[] memory rlpTx = txBytes.toRLPItem().toList(5);
         TX memory transaction;
 
         transaction.slot = uint64(rlpTx[0].toUint());
         transaction.prevBlock = rlpTx[1].toUint();
-        transaction.balance = rlpTx[2].toUint();
-        transaction.owner = rlpTx[3].toAddress();
+        transaction.nonce = rlpTx[2].toUint();
+        transaction.balance = rlpTx[3].toUint();
+        transaction.owner = rlpTx[4].toAddress();
         if (transaction.prevBlock == 0) { // deposit transaction
             transaction.hash = keccak256(abi.encodePacked(transaction.slot));
         } else {
@@ -33,7 +35,7 @@ library Transaction {
     }
 
     function getHash(bytes memory txBytes) internal pure returns (bytes32 hash) {
-        RLP.RLPItem[] memory rlpTx = txBytes.toRLPItem().toList(4);
+        RLP.RLPItem[] memory rlpTx = txBytes.toRLPItem().toList(5);
         uint64 slot = uint64(rlpTx[0].toUint());
         uint256 prevBlock = uint256(rlpTx[1].toUint());
 
@@ -44,13 +46,18 @@ library Transaction {
         }
     }
 
+    function getNonce(bytes memory txBytes) internal pure returns (uint256 nonce) {
+        RLP.RLPItem[] memory rlpTx = txBytes.toRLPItem().toList(5);
+        nonce = rlpTx[2].toUint();
+    }
+
     function getBalance(bytes memory txBytes) internal pure returns (uint256 balance) {
-        RLP.RLPItem[] memory rlpTx = txBytes.toRLPItem().toList(4);
-        balance = rlpTx[2].toUint();
+        RLP.RLPItem[] memory rlpTx = txBytes.toRLPItem().toList(5);
+        balance = rlpTx[3].toUint();
     }
 
     function getOwner(bytes memory txBytes) internal pure returns (address owner) {
-        RLP.RLPItem[] memory rlpTx = txBytes.toRLPItem().toList(4);
-        owner = rlpTx[3].toAddress();
+        RLP.RLPItem[] memory rlpTx = txBytes.toRLPItem().toList(5);
+        owner = rlpTx[4].toAddress();
     }
 }

--- a/server/test/UTXO.js
+++ b/server/test/UTXO.js
@@ -28,9 +28,10 @@ function signHash(from, hash) {
     return signature;
 };
 
-function createUTXO(slot, block, from, to) {
+function createUTXO(slot, block, from, to, denomination) {
     let rlpSlot = slot instanceof web3.BigNumber ? (new BN(slot.toString())).toBuffer() : slot;
-    let data = [rlpSlot, block, 1, to];
+    let coinDenom = denomination instanceof web3.BigNumber ? denomination : 1;
+    let data = [rlpSlot, block, coinDenom, to];
     data = '0x' + RLP.encode(data).toString('hex');
 
     // If it's a deposit transaction txHash = hash of the slot

--- a/server/test/testAllInOne.js
+++ b/server/test/testAllInOne.js
@@ -52,7 +52,7 @@ contract("Plasma Cash - All In One", async function(accounts) {
         await erc721.register({from: alice});
 
         for (let i = 0; i < denominations.length; i ++) {
-            await web3.eth.sendTransaction({from: alice, to: plasma.address, value: ethers[i], gas: 200000 });
+            await web3.eth.sendTransaction({from: alice, to: plasma.address, value: ethers[i], gas: 250000 });
             await erc20.depositToPlasma(denominations[i], {from: alice});
             await erc721.depositToPlasma(coins[i], {from: alice});
         }

--- a/server/test/testPlasmaDebit.js
+++ b/server/test/testPlasmaDebit.js
@@ -1,0 +1,125 @@
+const ValidatorManagerContract = artifacts.require("ValidatorManagerContract");
+const LoomToken = artifacts.require("LoomToken");
+const CryptoCards = artifacts.require("CryptoCards");
+const RootChain = artifacts.require("RootChain");
+import {increaseTimeTo, duration} from './helpers/increaseTime'
+import assertRevert from './helpers/assertRevert.js';
+
+const txlib = require('./UTXO.js')
+
+contract("Plasma Debit - All In One", async function(accounts) {
+
+    const t1 = 3600 * 24 * 3; // 3 days later
+    const t2 = 3600 * 24 * 5; // 5 days later
+
+    // Alice registers and has 5 coins, and she deposits 3 of them.
+    const ALICE_INITIAL_COINS = 5;
+    const ALICE_DEPOSITED_COINS = 3;
+    const coins = [1, 2, 3];
+
+    let erc20;
+    let erc721;
+    let plasma;
+    let vmc;
+    let events;
+    let t0;
+
+    let [authority, alice, bob, charlie, dylan, elliot, random_guy, random_guy2, challenger] = accounts;
+
+    const DECIMALS = 10 ** 18;
+    const denominations = [
+        3000 * DECIMALS, 
+        2000 * DECIMALS, 
+        4000 * DECIMALS
+    ];
+
+    const ethers = [
+        web3.toWei(1, 'ether'),
+        web3.toWei(4, 'ether'),
+        web3.toWei(5, 'ether')
+    ];
+
+    beforeEach(async function() {
+        vmc = await ValidatorManagerContract.new({from: authority});
+        plasma = await RootChain.new(vmc.address, {from: authority});
+        erc20 = await LoomToken.new(plasma.address, {from: authority});
+        erc721 = await CryptoCards.new(plasma.address, {from: authority});
+
+        await vmc.toggleToken(erc20.address, {from: authority});
+        await vmc.toggleToken(erc721.address, {from: authority});
+
+        await erc20.transfer(alice, 10000 * DECIMALS, {from: authority});
+        await erc721.register({from: alice});
+
+        for (let i = 0; i < denominations.length; i ++) {
+            await web3.eth.sendTransaction({from: alice, to: plasma.address, value: ethers[i], gas: 250000 });
+            await erc20.depositToPlasma(denominations[i], {from: alice});
+            await erc721.depositToPlasma(coins[i], {from: alice});
+        }
+        assert.equal(await erc20.balanceOf.call(alice), 1000 * DECIMALS);
+        assert.equal(await erc20.balanceOf.call(plasma.address), 9000 * DECIMALS);
+
+        assert.equal(await erc721.balanceOf.call(plasma.address), 3);
+        assert.equal(await erc721.balanceOf.call(alice), 2);
+
+        assert.equal(await web3.eth.getBalance(plasma.address), web3.toWei(10, 'ether'));
+
+        const depositEvent = plasma.Deposit({}, {fromBlock: 0, toBlock: 'latest'});
+        events = await txlib.Promisify(cb => depositEvent.get(cb));
+    });
+
+    describe('Plasma Debit', function() {
+		it('Operator provides liquidity!', async function() {
+			let UTXO = [
+                {'slot': events[0]['args'].slot, 'block': events[0]['args'].blockNumber.toNumber()},
+                {'slot': events[1]['args'].slot, 'block': events[1]['args'].blockNumber.toNumber()},
+            ]
+            // Fill up the ETH token
+            await plasma.provideLiquidity(UTXO[0].slot, 0, {'value':  web3.toWei(14, 'ether') });
+            // Fill up the ERC20 token
+            await erc20.approve(plasma.address, 4000 * DECIMALS, {from: authority});
+            await plasma.provideLiquidity(UTXO[1].slot, 4000 * DECIMALS, {from: authority});
+
+            let prevBlock = 0;
+            for (let i in UTXO) {
+                let aUTXO = UTXO[i];
+                let ret = txlib.createUTXO(aUTXO.slot, prevBlock, alice, alice);
+                let utxo = ret.tx;
+                let sig = ret.sig;
+
+                await plasma.startExit(
+                    aUTXO.slot,
+                    '0x', utxo,
+                    '0x0', '0x0',
+                    sig,
+                    [prevBlock, aUTXO.block],
+                    {'from': alice, 'value': web3.toWei(0.1, 'ether')}
+                );
+            }
+            t0 = (await web3.eth.getBlock('latest')).timestamp;
+            await increaseTimeTo(t0 + t1);
+            await plasma.finalizeExits({from: random_guy2 });
+
+            await increaseTimeTo(t0 + t1 + t2);
+            await plasma.finalizeExits({from: random_guy2 });
+            for (let i in UTXO) {
+                let aUTXO = UTXO[i];
+                await plasma.withdraw(aUTXO.slot, {from : alice });
+            }
+
+            const withdrewEvent = plasma.Withdrew({}, {fromBlock: 0, toBlock: 'latest'});
+            const withdrew = await txlib.Promisify(cb => withdrewEvent.get(cb));
+
+            // The authority should have got the liquidity provided back.
+            assert.equal(withdrew[0]['args'].denomination, web3.toWei(1, 'ether'));
+            assert.equal(withdrew[0]['args'].toOperator, web3.toWei(14, 'ether'));
+            assert.equal(withdrew[1]['args'].denomination, 3000 * DECIMALS);
+            assert.equal(withdrew[1]['args'].toOperator, 4000 * DECIMALS);
+            // Alice has her coins back.
+            await txlib.withdrawBonds(plasma, alice, 0.2);
+        });
+
+
+    });
+
+});

--- a/server/test/testPlasmaDebit.js
+++ b/server/test/testPlasmaDebit.js
@@ -16,6 +16,7 @@ contract("Plasma Debit - All In One", async function(accounts) {
     const ALICE_INITIAL_COINS = 5;
     const ALICE_DEPOSITED_COINS = 3;
     const coins = [1, 2, 3];
+    const ETHER = 10 ** 18;
 
     let erc20;
     let erc721;
@@ -74,16 +75,20 @@ contract("Plasma Debit - All In One", async function(accounts) {
                 {'slot': events[0]['args'].slot, 'block': events[0]['args'].blockNumber.toNumber()},
                 {'slot': events[1]['args'].slot, 'block': events[1]['args'].blockNumber.toNumber()},
             ]
-            // Fill up the ETH token
+            // Fill up the ETH token, had 1 ether
             await plasma.provideLiquidity(UTXO[0].slot, 0, {'value':  web3.toWei(14, 'ether') });
-            // Fill up the ERC20 token
+            // Fill up the ERC20 token, had 3000 erc20 coins
             await erc20.approve(plasma.address, 4000 * DECIMALS, {from: authority});
             await plasma.provideLiquidity(UTXO[1].slot, 4000 * DECIMALS, {from: authority});
 
+            // TODO Improve ux, if user does not provide a value the contract
+            // should be checking and automatically giving the user the default
+            // balance value
+            let values = [ 1 * ETHER, 3000 * DECIMALS ];
             let prevBlock = 0;
             for (let i in UTXO) {
                 let aUTXO = UTXO[i];
-                let ret = txlib.createUTXO(aUTXO.slot, prevBlock, alice, alice);
+                let ret = txlib.createDebitUTXO(aUTXO.slot, prevBlock, alice, alice, values[i], 0);
                 let utxo = ret.tx;
                 let sig = ret.sig;
 
@@ -119,6 +124,81 @@ contract("Plasma Debit - All In One", async function(accounts) {
             await txlib.withdrawBonds(plasma, alice, 0.2);
         });
 
+		it('User exits a partial coin', async function() {
+			let UTXO =
+                {'slot': events[0]['args'].slot, 'block': events[0]['args'].blockNumber.toNumber()};
+            let prevBlock = 0;
+
+            // Auth and Alice sign nonce 0
+            let changeBalance = txlib.createDebitUTXO(
+                UTXO.slot,
+                UTXO.block,
+                alice,
+                alice,
+                0.75 * ETHER,
+                0
+            ); // Alice has now signed the TXO.
+
+            let auth_sig = txlib.signHash(authority, changeBalance.hash);
+
+            // Auth and alice now sign nonce 1
+            changeBalance = txlib.createDebitUTXO(
+                UTXO.slot,
+                UTXO.block,
+                alice,
+                alice,
+                0.6 * ETHER,
+                1
+            );
+
+            auth_sig = txlib.signHash(authority, changeBalance.hash);
+
+            // Alice should be able to exit this TXO and get 0.5 out of the 1
+            // ether.
+
+            let utxo = changeBalance.tx;
+            let sig = changeBalance.sig;
+            let txs = [changeBalance.leaf]
+
+            // Authority submits a block to plasma with that transaction included
+            let tree = await txlib.submitTransactions(authority, plasma, txs);
+            let submittedBlock = 1000;
+
+            let exiting_tx_proof = tree.createMerkleProof(UTXO.slot)
+
+            // Auth and alice now sign nonce 1
+            let prev_tx = txlib.createDebitUTXO(
+                UTXO.slot,
+                0,
+                alice,
+                alice,
+                1 * ETHER,
+                0
+            ).tx;
+
+            await plasma.startExit(
+                UTXO.slot,
+                prev_tx, utxo,
+                '0x0', exiting_tx_proof,
+                sig,
+                [UTXO.block, submittedBlock],
+                {'from': alice, 'value': web3.toWei(0.1, 'ether')}
+            );
+
+            t0 = (await web3.eth.getBlock('latest')).timestamp;
+            await increaseTimeTo(t0 + t1 + t2);
+            await plasma.finalizeExits({from: random_guy2 });
+
+            await plasma.withdraw(UTXO.slot, {from : alice });
+
+            const withdrewEvent = plasma.Withdrew({}, {fromBlock: 0, toBlock: 'latest'});
+            const withdrew = await txlib.Promisify(cb => withdrewEvent.get(cb));
+
+            // The authority should have got the liquidity provided back.
+            assert.equal(withdrew[0]['args'].denomination, web3.toWei(0.6, 'ether'));
+            assert.equal(withdrew[0]['args'].toOperator, web3.toWei(0.4, 'ether'));
+            await txlib.withdrawBonds(plasma, alice, 0.1);
+        });
 
     });
 


### PR DESCRIPTION
Implementing Plasma Debit. Very experimental, still no spec for conciseness.

Currently supports partial withdrawals where a user will get `a` and the operator `v-a`.
If the operator cheats and submits an earlier nonce they can get challenged and forfeit the whole coin in a similar fashion to how the whole value inside a payment channel goes to the challenger if they win the dispute. Response still not impemented but will require the op to prove that a tx with a higher nonce was either signed by the user or was the one included in the block in question (probably?)
Also supports liquidity injections by the operator in a coin