### PR TITLE
Fix test for user api

### DIFF
--- a/loom_integration_test.sh
+++ b/loom_integration_test.sh
@@ -6,7 +6,7 @@
 set -exo pipefail
 
 # Loom build to use for tests when running on Jenkins, this build will be automatically downloaded.
-BUILD_NUMBER=470
+BUILD_NUMBER=478
 
 # These can be toggled via the options below, only useful when running the script locally.
 LOOM_INIT_ONLY=false

--- a/loom_integration_test.sh
+++ b/loom_integration_test.sh
@@ -168,6 +168,7 @@ init_honest_dappchain
 start_chains
 
 cd $REPO_ROOT/loom_js_test
+mkdir -p db
 rm -rf db/*.json # remove all previously stored db related files
 
 yarn jenkins:test:honest
@@ -180,6 +181,7 @@ init_hostile_dappchain
 start_chains
 
 cd $REPO_ROOT/loom_js_test
+rm -rf db/*.json # remove all previously stored db related files
 yarn jenkins:test:hostile
 
 # If the script gets this far then nothing failed and we can wipe out the working dir since we

--- a/loom_js_test/package.json
+++ b/loom_js_test/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "bn.js": "^4.11.8",
     "ethereumjs-util": "^5.2.0",
-    "loom-js": "^1.26.0",
+    "loom-js": "git+https://github.com/loomnetwork/loom-js.git#build-files",
     "rlp": "^2.1.0",
     "web3": "^1.0.0-beta.34"
   },

--- a/loom_js_test/package.json
+++ b/loom_js_test/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "bn.js": "^4.11.8",
     "ethereumjs-util": "^5.2.0",
-    "loom-js": "git+https://github.com/loomnetwork/loom-js.git#build-files",
+    "loom-js": "^1.27.0",
     "rlp": "^2.1.0",
     "web3": "^1.0.0-beta.34"
   },

--- a/loom_js_test/src/challenge-after-demo.ts
+++ b/loom_js_test/src/challenge-after-demo.ts
@@ -49,10 +49,7 @@ export async function runChallengeAfterDemo(t: test.Test) {
   const coin = await mallory.getPlasmaCoinAsync(deposit1Slot)
   await mallory.transferAsync(deposit1Slot, dan.ethAddress)
   await authority.submitPlasmaBlockAsync()
-
-  const blocks = await mallory.getBlockNumbersAsync(coin.depositBlockNum)
-  const proofs = await mallory.getCoinHistoryAsync(deposit1Slot, blocks)
-  t.equal(await dan.verifyCoinHistoryAsync(deposit1Slot, proofs), true)
+  t.equal(await dan.checkHistoryAsync(coin), true, "Coin history verified")
   const danCoin = dan.watchExit(deposit1Slot, coin.depositBlockNum)
 
 

--- a/loom_js_test/src/challenge-after-demo.ts
+++ b/loom_js_test/src/challenge-after-demo.ts
@@ -4,15 +4,7 @@ import BN from 'bn.js'
 import { createUser } from 'loom-js'
 
 import { increaseTime, getEthBalanceAtAddress } from './ganache-helpers'
-import { sleep, createTestEntity, ADDRESSES, ACCOUNTS } from './config'
-import { EthCardsContract } from './cards-contract'
-
-// All the contracts are expected to have been deployed to Ganache when this function is called.
-function setupContracts(web3: Web3): { cards: EthCardsContract } {
-  const abi = require('./contracts/cards-abi.json')
-  const cards = new EthCardsContract(new web3.eth.Contract(abi, ADDRESSES.token_contract))
-  return { cards }
-}
+import { sleep, ADDRESSES, ACCOUNTS, setupContracts } from './config'
 
 export async function runChallengeAfterDemo(t: test.Test) {
   const web3Endpoint = 'ws://127.0.0.1:8545'

--- a/loom_js_test/src/challenge-after-demo.ts
+++ b/loom_js_test/src/challenge-after-demo.ts
@@ -12,9 +12,24 @@ export async function runChallengeAfterDemo(t: test.Test) {
   const web3 = new Web3(new Web3.providers.WebsocketProvider(web3Endpoint))
   const { cards } = setupContracts(web3)
 
-  const authority = PlasmaUser.createUser(web3Endpoint, ADDRESSES.root_chain, dappchainEndpoint, ACCOUNTS.authority)
-  const mallory = PlasmaUser.createUser(web3Endpoint, ADDRESSES.root_chain, dappchainEndpoint, ACCOUNTS.mallory)
-  const dan = PlasmaUser.createUser(web3Endpoint, ADDRESSES.root_chain, dappchainEndpoint, ACCOUNTS.dan)
+  const authority = PlasmaUser.createUser(
+    web3Endpoint,
+    ADDRESSES.root_chain,
+    dappchainEndpoint,
+    ACCOUNTS.authority
+  )
+  const mallory = PlasmaUser.createUser(
+    web3Endpoint,
+    ADDRESSES.root_chain,
+    dappchainEndpoint,
+    ACCOUNTS.mallory
+  )
+  const dan = PlasmaUser.createUser(
+    web3Endpoint,
+    ADDRESSES.root_chain,
+    dappchainEndpoint,
+    ACCOUNTS.dan
+  )
 
   // Give Mallory 5 tokens
   await cards.registerAsync(mallory.ethAddress)
@@ -49,9 +64,8 @@ export async function runChallengeAfterDemo(t: test.Test) {
   const coin = await mallory.getPlasmaCoinAsync(deposit1Slot)
   await mallory.transferAsync(deposit1Slot, dan.ethAddress)
   await authority.submitPlasmaBlockAsync()
-  t.equal(await dan.checkHistoryAsync(coin), true, "Coin history verified")
+  t.equal(await dan.checkHistoryAsync(coin), true, 'Coin history verified')
   const danCoin = dan.watchExit(deposit1Slot, coin.depositBlockNum)
-
 
   // Mallory attempts to exit spent coin (the one sent to Dan)
   // Needs to use the low level API to make an invalid tx
@@ -64,7 +78,7 @@ export async function runChallengeAfterDemo(t: test.Test) {
   // Having successufly challenged Mallory's exit Dan should be able to exit the coin
   await sleep(2000)
   await dan.exitAsync(deposit1Slot)
-  
+
   dan.stopWatching(danCoin)
 
   // Jump forward in time by 8 days

--- a/loom_js_test/src/challenge-after-demo.ts
+++ b/loom_js_test/src/challenge-after-demo.ts
@@ -75,7 +75,7 @@ export async function runChallengeAfterDemo(t: test.Test) {
 
   await authority.finalizeExitsAsync()
 
-  await dan.withdrawCoinAsync(deposit1Slot)
+  await dan.withdrawAsync(deposit1Slot)
 
   const danBalanceBefore = await getEthBalanceAtAddress(web3, dan.ethAddress)
   await dan.withdrawBondsAsync()

--- a/loom_js_test/src/challenge-before-demo.ts
+++ b/loom_js_test/src/challenge-before-demo.ts
@@ -1,7 +1,7 @@
 import test from 'tape'
 import BN from 'bn.js'
 import Web3 from 'web3'
-import { IPlasmaDeposit, marshalDepositEvent, createUser } from 'loom-js'
+import { createUser } from 'loom-js'
 
 import { increaseTime, getEthBalanceAtAddress } from './ganache-helpers'
 import { sleep, ADDRESSES, ACCOUNTS, setupContracts } from './config'

--- a/loom_js_test/src/challenge-before-demo.ts
+++ b/loom_js_test/src/challenge-before-demo.ts
@@ -1,31 +1,21 @@
 import test from 'tape'
 import BN from 'bn.js'
 import Web3 from 'web3'
-import { IPlasmaDeposit, marshalDepositEvent } from 'loom-js'
+import { IPlasmaDeposit, marshalDepositEvent, createUser } from 'loom-js'
 
 import { increaseTime, getEthBalanceAtAddress } from './ganache-helpers'
-import { sleep, createTestEntity, ADDRESSES, ACCOUNTS } from './config'
-import { EthCardsContract } from './cards-contract'
-
-// Alice registers and has 5 coins, and she deposits 3 of them.
-const ALICE_INITIAL_COINS = 5
-const ALICE_DEPOSITED_COINS = 3
-const COINS = [1, 2, 3]
-
-// All the contracts are expected to have been deployed to Ganache when this function is called.
-function setupContracts(web3: Web3): { cards: EthCardsContract } {
-  const abi = require('./contracts/cards-abi.json')
-  const cards = new EthCardsContract(new web3.eth.Contract(abi, ADDRESSES.token_contract))
-  return { cards }
-}
+import { sleep, ADDRESSES, ACCOUNTS, setupContracts } from './config'
 
 export async function runChallengeBeforeDemo(t: test.Test) {
-  const web3 = new Web3(new Web3.providers.WebsocketProvider('ws://localhost:8545'))
+  const web3Endpoint = 'ws://127.0.0.1:8545'
+  const dappchainEndpoint = 'http://localhost:46658'
+  const web3 = new Web3(new Web3.providers.WebsocketProvider(web3Endpoint))
   const { cards } = setupContracts(web3)
-  const authority = createTestEntity(web3, ACCOUNTS.authority)
-  const dan = createTestEntity(web3, ACCOUNTS.dan)
-  const trudy = createTestEntity(web3, ACCOUNTS.trudy)
-  const mallory = createTestEntity(web3, ACCOUNTS.mallory)
+
+  const authority = createUser(web3Endpoint, ADDRESSES.root_chain, dappchainEndpoint, ACCOUNTS.authority)
+  const dan  = createUser(web3Endpoint, ADDRESSES.root_chain, dappchainEndpoint, ACCOUNTS.dan)
+  const trudy = createUser(web3Endpoint, ADDRESSES.root_chain, dappchainEndpoint, ACCOUNTS.trudy)
+  const mallory = createUser(web3Endpoint, ADDRESSES.root_chain, dappchainEndpoint, ACCOUNTS.mallory)
 
   // Give Dan 5 tokens
   await cards.registerAsync(dan.ethAddress)
@@ -36,13 +26,7 @@ export async function runChallengeBeforeDemo(t: test.Test) {
 
   // Dan deposits a coin
   await cards.depositToPlasmaAsync({ tokenId: 16, from: dan.ethAddress })
-
-  const depositEvents: any[] = await authority.plasmaCashContract.getPastEvents('Deposit', {
-    fromBlock: startBlockNum
-  })
-  const deposits = depositEvents.map<IPlasmaDeposit>(event =>
-    marshalDepositEvent(event.returnValues)
-  )
+  const deposits = await dan.deposits()
   t.equal(deposits.length, 1, 'All deposit events accounted for')
 
   await sleep(8000)
@@ -56,6 +40,7 @@ export async function runChallengeBeforeDemo(t: test.Test) {
   const danCoin = dan.watchExit(deposit1Slot, coin.depositBlockNum)
 
   // Trudy creates an invalid spend of the coin to Mallory
+  // Low level call since trudy doesn't actually have the data for this transfer in her state
   await trudy.transferTokenAsync({
     slot: deposit1Slot,
     prevBlockNum: coin.depositBlockNum,
@@ -66,7 +51,8 @@ export async function runChallengeBeforeDemo(t: test.Test) {
   // Operator includes it
   const trudyToMalloryBlock = await authority.submitPlasmaBlockAsync()
 
-  // Mallory gives the coin back to Trudy.
+  
+  // Low level call for the malicious transfers
   await mallory.transferTokenAsync({
     slot: deposit1Slot,
     prevBlockNum: trudyToMalloryBlock,
@@ -77,6 +63,7 @@ export async function runChallengeBeforeDemo(t: test.Test) {
   // Operator includes it
   const malloryToTrudyBlock = await authority.submitPlasmaBlockAsync()
 
+  // Low level call for the malicious exit
   await trudy.startExitAsync({
     slot: deposit1Slot,
     prevBlockNum: trudyToMalloryBlock,
@@ -116,5 +103,14 @@ export async function runChallengeBeforeDemo(t: test.Test) {
   // Close the websocket, hacky :/
   // @ts-ignore
   web3.currentProvider.connection.close()
+  // @ts-ignore
+  authority.web3.currentProvider.connection.close()
+  // @ts-ignore
+  dan.web3.currentProvider.connection.close()
+  // @ts-ignore
+  trudy.web3.currentProvider.connection.close()
+  // @ts-ignore
+  mallory.web3.currentProvider.connection.close()
+
   t.end()
 }

--- a/loom_js_test/src/challenge-before-demo.ts
+++ b/loom_js_test/src/challenge-before-demo.ts
@@ -1,7 +1,7 @@
 import test from 'tape'
 import BN from 'bn.js'
 import Web3 from 'web3'
-import { createUser } from 'loom-js'
+import { PlasmaUser } from 'loom-js'
 
 import { increaseTime, getEthBalanceAtAddress } from './ganache-helpers'
 import { sleep, ADDRESSES, ACCOUNTS, setupContracts } from './config'
@@ -12,10 +12,10 @@ export async function runChallengeBeforeDemo(t: test.Test) {
   const web3 = new Web3(new Web3.providers.WebsocketProvider(web3Endpoint))
   const { cards } = setupContracts(web3)
 
-  const authority = createUser(web3Endpoint, ADDRESSES.root_chain, dappchainEndpoint, ACCOUNTS.authority)
-  const dan  = createUser(web3Endpoint, ADDRESSES.root_chain, dappchainEndpoint, ACCOUNTS.dan)
-  const trudy = createUser(web3Endpoint, ADDRESSES.root_chain, dappchainEndpoint, ACCOUNTS.trudy)
-  const mallory = createUser(web3Endpoint, ADDRESSES.root_chain, dappchainEndpoint, ACCOUNTS.mallory)
+  const authority = PlasmaUser.createUser(web3Endpoint, ADDRESSES.root_chain, dappchainEndpoint, ACCOUNTS.authority)
+  const dan  = PlasmaUser.createUser(web3Endpoint, ADDRESSES.root_chain, dappchainEndpoint, ACCOUNTS.dan)
+  const trudy = PlasmaUser.createUser(web3Endpoint, ADDRESSES.root_chain, dappchainEndpoint, ACCOUNTS.trudy)
+  const mallory = PlasmaUser.createUser(web3Endpoint, ADDRESSES.root_chain, dappchainEndpoint, ACCOUNTS.mallory)
 
   // Give Dan 5 tokens
   await cards.registerAsync(dan.ethAddress)
@@ -103,14 +103,9 @@ export async function runChallengeBeforeDemo(t: test.Test) {
   // Close the websocket, hacky :/
   // @ts-ignore
   web3.currentProvider.connection.close()
-  // @ts-ignore
-  authority.web3.currentProvider.connection.close()
-  // @ts-ignore
-  dan.web3.currentProvider.connection.close()
-  // @ts-ignore
-  trudy.web3.currentProvider.connection.close()
-  // @ts-ignore
-  mallory.web3.currentProvider.connection.close()
-
+  authority.disconnect()
+  dan.disconnect()
+  trudy.disconnect()
+  mallory.disconnect()
   t.end()
 }

--- a/loom_js_test/src/challenge-before-demo.ts
+++ b/loom_js_test/src/challenge-before-demo.ts
@@ -12,10 +12,30 @@ export async function runChallengeBeforeDemo(t: test.Test) {
   const web3 = new Web3(new Web3.providers.WebsocketProvider(web3Endpoint))
   const { cards } = setupContracts(web3)
 
-  const authority = PlasmaUser.createUser(web3Endpoint, ADDRESSES.root_chain, dappchainEndpoint, ACCOUNTS.authority)
-  const dan  = PlasmaUser.createUser(web3Endpoint, ADDRESSES.root_chain, dappchainEndpoint, ACCOUNTS.dan)
-  const trudy = PlasmaUser.createUser(web3Endpoint, ADDRESSES.root_chain, dappchainEndpoint, ACCOUNTS.trudy)
-  const mallory = PlasmaUser.createUser(web3Endpoint, ADDRESSES.root_chain, dappchainEndpoint, ACCOUNTS.mallory)
+  const authority = PlasmaUser.createUser(
+    web3Endpoint,
+    ADDRESSES.root_chain,
+    dappchainEndpoint,
+    ACCOUNTS.authority
+  )
+  const dan = PlasmaUser.createUser(
+    web3Endpoint,
+    ADDRESSES.root_chain,
+    dappchainEndpoint,
+    ACCOUNTS.dan
+  )
+  const trudy = PlasmaUser.createUser(
+    web3Endpoint,
+    ADDRESSES.root_chain,
+    dappchainEndpoint,
+    ACCOUNTS.trudy
+  )
+  const mallory = PlasmaUser.createUser(
+    web3Endpoint,
+    ADDRESSES.root_chain,
+    dappchainEndpoint,
+    ACCOUNTS.mallory
+  )
 
   // Give Dan 5 tokens
   await cards.registerAsync(dan.ethAddress)
@@ -51,7 +71,6 @@ export async function runChallengeBeforeDemo(t: test.Test) {
   // Operator includes it
   const trudyToMalloryBlock = await authority.submitPlasmaBlockAsync()
 
-  
   // Low level call for the malicious transfers
   await mallory.transferTokenAsync({
     slot: deposit1Slot,

--- a/loom_js_test/src/challenge-between-demo.ts
+++ b/loom_js_test/src/challenge-between-demo.ts
@@ -33,12 +33,9 @@ export async function runChallengeBetweenDemo(t: test.Test) {
   // Eve sends her plasma coin to Bob
   const coin = await eve.getPlasmaCoinAsync(deposit1Slot)
   await eve.transferAsync(deposit1Slot, bob.ethAddress)
-
   const eveToBobBlockNum = await authority.submitPlasmaBlockAsync()
 
-  const blocks = await eve.getBlockNumbersAsync(coin.depositBlockNum)
-  const proofs = await eve.getCoinHistoryAsync(deposit1Slot, blocks)
-  t.equal(await bob.verifyCoinHistoryAsync(deposit1Slot, proofs), true)
+  t.equal(await bob.checkHistoryAsync(coin), true, "Coin history verified")
   const bobCoin = bob.watchExit(deposit1Slot, coin.depositBlockNum)
 
   // Eve sends this same plasma coin to Alice

--- a/loom_js_test/src/challenge-between-demo.ts
+++ b/loom_js_test/src/challenge-between-demo.ts
@@ -1,6 +1,6 @@
 import test from 'tape'
 import Web3 from 'web3'
-import { createUser, IPlasmaDeposit, marshalDepositEvent } from 'loom-js'
+import { createUser } from 'loom-js'
 
 import { increaseTime, getEthBalanceAtAddress } from './ganache-helpers'
 import { sleep, ADDRESSES, ACCOUNTS, setupContracts } from './config'

--- a/loom_js_test/src/challenge-between-demo.ts
+++ b/loom_js_test/src/challenge-between-demo.ts
@@ -11,10 +11,30 @@ export async function runChallengeBetweenDemo(t: test.Test) {
   const web3 = new Web3(new Web3.providers.WebsocketProvider(web3Endpoint))
   const { cards } = setupContracts(web3)
 
-  const authority = PlasmaUser.createUser(web3Endpoint, ADDRESSES.root_chain, dappchainEndpoint, ACCOUNTS.authority)
-  const alice = PlasmaUser.createUser(web3Endpoint, ADDRESSES.root_chain, dappchainEndpoint, ACCOUNTS.alice)
-  const bob = PlasmaUser.createUser(web3Endpoint, ADDRESSES.root_chain, dappchainEndpoint, ACCOUNTS.bob)
-  const eve = PlasmaUser.createUser(web3Endpoint, ADDRESSES.root_chain, dappchainEndpoint, ACCOUNTS.eve)
+  const authority = PlasmaUser.createUser(
+    web3Endpoint,
+    ADDRESSES.root_chain,
+    dappchainEndpoint,
+    ACCOUNTS.authority
+  )
+  const alice = PlasmaUser.createUser(
+    web3Endpoint,
+    ADDRESSES.root_chain,
+    dappchainEndpoint,
+    ACCOUNTS.alice
+  )
+  const bob = PlasmaUser.createUser(
+    web3Endpoint,
+    ADDRESSES.root_chain,
+    dappchainEndpoint,
+    ACCOUNTS.bob
+  )
+  const eve = PlasmaUser.createUser(
+    web3Endpoint,
+    ADDRESSES.root_chain,
+    dappchainEndpoint,
+    ACCOUNTS.eve
+  )
 
   const bobTokensStart = await cards.balanceOfAsync(bob.ethAddress)
 
@@ -35,7 +55,7 @@ export async function runChallengeBetweenDemo(t: test.Test) {
   await eve.transferAsync(deposit1Slot, bob.ethAddress)
   const eveToBobBlockNum = await authority.submitPlasmaBlockAsync()
 
-  t.equal(await bob.checkHistoryAsync(coin), true, "Coin history verified")
+  t.equal(await bob.checkHistoryAsync(coin), true, 'Coin history verified')
   const bobCoin = bob.watchExit(deposit1Slot, coin.depositBlockNum)
 
   // Eve sends this same plasma coin to Alice

--- a/loom_js_test/src/challenge-between-demo.ts
+++ b/loom_js_test/src/challenge-between-demo.ts
@@ -65,7 +65,7 @@ export async function runChallengeBetweenDemo(t: test.Test) {
 
   await authority.finalizeExitsAsync()
 
-  await bob.withdrawCoinAsync(deposit1Slot)
+  await bob.withdrawAsync(deposit1Slot)
 
   const bobBalanceBefore = await getEthBalanceAtAddress(web3, bob.ethAddress)
 

--- a/loom_js_test/src/config.ts
+++ b/loom_js_test/src/config.ts
@@ -14,6 +14,7 @@ import {
   createJSONRPCClient,
   Entity
 } from 'loom-js'
+import { EthCardsContract } from './cards-contract';
 
 export const DEFAULT_GAS = '3141592'
 export const CHILD_BLOCK_INTERVAL = 1000
@@ -48,6 +49,13 @@ export function getTestUrls() {
     httpWriteUrl: process.env.TEST_LOOM_DAPP_HTTP_WRITE_URL || 'http://127.0.0.1:46658/rpc',
     httpReadUrl: process.env.TEST_LOOM_DAPP_HTTP_READ_URL || 'http://127.0.0.1:46658/query'
   }
+}
+
+// All the contracts are expected to have been deployed to Ganache when this function is called.
+export function setupContracts(web3: Web3): { cards: EthCardsContract } {
+  const abi = require('./contracts/cards-abi.json')
+  const cards = new EthCardsContract(new web3.eth.Contract(abi, ADDRESSES.token_contract))
+  return { cards }
 }
 
 var useHostileOperator = false

--- a/loom_js_test/src/config.ts
+++ b/loom_js_test/src/config.ts
@@ -1,6 +1,6 @@
 import Web3 from 'web3'
 import {
-  Entity,
+  User,
   EthereumPlasmaClient,
   CryptoUtils,
   NonceTxMiddleware,
@@ -11,7 +11,8 @@ import {
   CachedDAppChainPlasmaClient,
   Client,
   PlasmaDB,
-  createJSONRPCClient
+  createJSONRPCClient,
+  Entity
 } from 'loom-js'
 
 export const DEFAULT_GAS = '3141592'
@@ -69,17 +70,14 @@ export function createTestEntity(web3: Web3, ethPrivateKey: string, database?: P
   ]
   const callerAddress = new Address('default', LocalAddress.fromPublicKey(pubKey))
   const contractName = useHostileOperator ? 'hostileoperator' : undefined
-  let dAppPlasmaClient
-  if (database !== undefined) {
-    dAppPlasmaClient = new CachedDAppChainPlasmaClient({ dAppClient, callerAddress, database, contractName })
-  } else {
-    dAppPlasmaClient = new DAppChainPlasmaClient({ dAppClient, callerAddress, contractName })
-  }
-  return new Entity(web3, {
+  const dAppPlasmaClient = new DAppChainPlasmaClient({ dAppClient, callerAddress, contractName })
+  // @ts-ignore
+  return new User(web3, {
     ethAccount,
     ethPlasmaClient,
     dAppPlasmaClient,
     defaultGas: DEFAULT_GAS,
     childBlockInterval: CHILD_BLOCK_INTERVAL
-  })
+  }
+  )
 }

--- a/loom_js_test/src/config.ts
+++ b/loom_js_test/src/config.ts
@@ -1,18 +1,4 @@
 import Web3 from 'web3'
-import {
-  User,
-  EthereumPlasmaClient,
-  CryptoUtils,
-  NonceTxMiddleware,
-  SignedTxMiddleware,
-  Address,
-  LocalAddress,
-  DAppChainPlasmaClient,
-  Client,
-  PlasmaDB,
-  createJSONRPCClient,
-  Entity
-} from 'loom-js'
 import { EthCardsContract } from './cards-contract';
 
 export const DEFAULT_GAS = '3141592'
@@ -55,35 +41,4 @@ export function setupContracts(web3: Web3): { cards: EthCardsContract } {
   const abi = require('./contracts/cards-abi.json')
   const cards = new EthCardsContract(new web3.eth.Contract(abi, ADDRESSES.token_contract))
   return { cards }
-}
-
-var useHostileOperator = false
-export function enableHostilePlasmaCashOperator(enable: boolean) {
-  useHostileOperator = enable
-}
-
-export function createTestEntity(web3: Web3, ethPrivateKey: string, database: PlasmaDB): Entity {
-  const ethAccount = web3.eth.accounts.privateKeyToAccount(ethPrivateKey)
-  const ethPlasmaClient = new EthereumPlasmaClient(web3, ethAccount, ADDRESSES.root_chain)
-  const writer = createJSONRPCClient({ protocols: [{ url: getTestUrls().httpWriteUrl }] })
-  const reader = createJSONRPCClient({ protocols: [{ url: getTestUrls().httpReadUrl }] })
-  const dAppClient = new Client('default', writer, reader)
-  // TODO: move keys to config file
-  const privKey = CryptoUtils.generatePrivateKey()
-  const pubKey = CryptoUtils.publicKeyFromPrivateKey(privKey)
-  dAppClient.txMiddleware = [
-    new NonceTxMiddleware(pubKey, dAppClient),
-    new SignedTxMiddleware(privKey)
-  ]
-  const callerAddress = new Address('default', LocalAddress.fromPublicKey(pubKey))
-  const contractName = useHostileOperator ? 'hostileoperator' : undefined
-  const dAppPlasmaClient = new DAppChainPlasmaClient({ dAppClient, callerAddress, contractName, database })
-  return new User(web3, {
-    ethAccount,
-    ethPlasmaClient,
-    dAppPlasmaClient,
-    defaultGas: DEFAULT_GAS,
-    childBlockInterval: CHILD_BLOCK_INTERVAL
-  }
-  )
 }

--- a/loom_js_test/src/config.ts
+++ b/loom_js_test/src/config.ts
@@ -1,5 +1,5 @@
 import Web3 from 'web3'
-import { EthCardsContract } from './cards-contract';
+import { EthCardsContract } from './cards-contract'
 
 export const DEFAULT_GAS = '3141592'
 export const CHILD_BLOCK_INTERVAL = 1000

--- a/loom_js_test/src/config.ts
+++ b/loom_js_test/src/config.ts
@@ -8,7 +8,6 @@ import {
   Address,
   LocalAddress,
   DAppChainPlasmaClient,
-  CachedDAppChainPlasmaClient,
   Client,
   PlasmaDB,
   createJSONRPCClient,
@@ -63,7 +62,7 @@ export function enableHostilePlasmaCashOperator(enable: boolean) {
   useHostileOperator = enable
 }
 
-export function createTestEntity(web3: Web3, ethPrivateKey: string, database?: PlasmaDB): Entity {
+export function createTestEntity(web3: Web3, ethPrivateKey: string, database: PlasmaDB): Entity {
   const ethAccount = web3.eth.accounts.privateKeyToAccount(ethPrivateKey)
   const ethPlasmaClient = new EthereumPlasmaClient(web3, ethAccount, ADDRESSES.root_chain)
   const writer = createJSONRPCClient({ protocols: [{ url: getTestUrls().httpWriteUrl }] })
@@ -78,8 +77,7 @@ export function createTestEntity(web3: Web3, ethPrivateKey: string, database?: P
   ]
   const callerAddress = new Address('default', LocalAddress.fromPublicKey(pubKey))
   const contractName = useHostileOperator ? 'hostileoperator' : undefined
-  const dAppPlasmaClient = new DAppChainPlasmaClient({ dAppClient, callerAddress, contractName })
-  // @ts-ignore
+  const dAppPlasmaClient = new DAppChainPlasmaClient({ dAppClient, callerAddress, contractName, database })
   return new User(web3, {
     ethAccount,
     ethPlasmaClient,

--- a/loom_js_test/src/demo.ts
+++ b/loom_js_test/src/demo.ts
@@ -1,10 +1,9 @@
 import test from 'tape'
-import BN from 'bn.js'
 import Web3 from 'web3'
-import { PlasmaDB, SignedContract, IPlasmaDeposit, marshalDepositEvent } from 'loom-js'
+import { createUser } from 'loom-js'
 
 import { increaseTime } from './ganache-helpers'
-import { sleep, createTestEntity, ADDRESSES, ACCOUNTS } from './config'
+import { sleep, ADDRESSES, ACCOUNTS } from './config'
 import { EthCardsContract } from './cards-contract'
 
 // Alice registers and has 5 coins, and she deposits 3 of them.
@@ -20,28 +19,26 @@ function setupContracts(web3: Web3): { cards: EthCardsContract } {
 }
 
 export async function runDemo(t: test.Test) {
-  const endpoint = 'ws://127.0.0.1:8545'
-  const web3 = new Web3(new Web3.providers.WebsocketProvider(endpoint))
+  const web3Endpoint = 'ws://127.0.0.1:8545'
+  const dappchainEndpoint = 'http://localhost:46658'
+  const web3 = new Web3(new Web3.providers.WebsocketProvider(web3Endpoint))
   const { cards } = setupContracts(web3)
-  const database = new PlasmaDB(endpoint, 'localhost:45578', '0x', ACCOUNTS.charlie) // Demo values to store in the db
 
-  const authority = createTestEntity(web3, ACCOUNTS.authority)
-  const alice = createTestEntity(web3, ACCOUNTS.alice)
-  const bob = createTestEntity(web3, ACCOUNTS.bob)
-  const charlie = createTestEntity(web3, ACCOUNTS.charlie, database)
+  const authority = createUser(web3Endpoint, ADDRESSES.root_chain, dappchainEndpoint, ACCOUNTS.authority)
+  const alice = createUser(web3Endpoint, ADDRESSES.root_chain, dappchainEndpoint, ACCOUNTS.alice)
+  const bob = createUser(web3Endpoint, ADDRESSES.root_chain, dappchainEndpoint, ACCOUNTS.bob)
+  const charlie = createUser(web3Endpoint, ADDRESSES.root_chain, dappchainEndpoint, ACCOUNTS.charlie)
 
   await cards.registerAsync(alice.ethAddress)
   let balance = await cards.balanceOfAsync(alice.ethAddress)
   t.equal(balance.toNumber(), 5)
-
-  const startBlockNum = await web3.eth.getBlockNumber()
 
   for (let i = 0; i < ALICE_DEPOSITED_COINS; i++) {
     await cards.depositToPlasmaAsync({ tokenId: COINS[i], from: alice.ethAddress })
   }
 
   // Get deposit events for all
-  const deposits: IPlasmaDeposit[] = await authority.getDepositEvents(new BN(0), true)
+  const deposits = await authority.allDeposits()
   t.equal(deposits.length, ALICE_DEPOSITED_COINS, 'All deposit events accounted for')
 
   // for (let i = 0; i < deposits.length; i++) {
@@ -73,49 +70,49 @@ export async function runDemo(t: test.Test) {
 
   // Alice to Bob, and Alice to Charlie. We care about the Alice to Bob
   // transaction
-  const deposit3 = deposits[2]
   const deposit2 = deposits[1]
+  const deposit3 = deposits[2]
   // Alice -> Bob
-  await alice.transferTokenAsync({
-    slot: deposit3.slot,
-    prevBlockNum: deposit3.blockNumber,
-    denomination: 1,
-    newOwner: bob.ethAddress
-  })
+  await alice.transfer(deposit3.slot, bob.ethAddress)
   // Alice -> Charlie
-  await alice.transferTokenAsync({
-    slot: deposit2.slot,
-    prevBlockNum: deposit2.blockNumber,
-    denomination: 1,
-    newOwner: charlie.ethAddress
-  })
-  const plasmaBlockNum1 = await authority.submitPlasmaBlockAsync()
+  await alice.transfer(deposit2.slot, charlie.ethAddress)
+
+  let aliceCoins = await alice.getUserCoinsAsync()
+  t.ok(aliceCoins[0].slot.eq(deposits[0].slot), "Alice has correct coin")
+
+  await authority.submitPlasmaBlockAsync()
 
   // Add an empty block in between (for proof of exclusion)
   await authority.submitPlasmaBlockAsync()
 
+  let bobCoins = await bob.getUserCoinsAsync()
+  t.ok(bobCoins[0].slot.eq(deposit3.slot), "Bob has correct coin")
+
+  let charlieCoins = await charlie.getUserCoinsAsync()
+  t.ok(charlieCoins[0].slot.eq(deposit2.slot), "Charlie has correct coin")
+
+
+  // Multiple refreshes don't break it
+  await bob.refreshAsync()
+  await bob.refreshAsync()
+  await bob.refreshAsync()
+
   // Bob -> Charlie
-  await bob.transferTokenAsync({
-    slot: deposit3.slot,
-    prevBlockNum: new BN(1000),
-    denomination: 1,
-    newOwner: charlie.ethAddress
-  })
-  const plasmaBlockNum2 = await authority.submitPlasmaBlockAsync()
+  await bob.transfer(deposit3.slot, charlie.ethAddress)
+
+  await authority.submitPlasmaBlockAsync()
+
+  await charlie.refreshAsync()
+  await charlie.refreshAsync()
+  await charlie.refreshAsync()
 
   const coin = await charlie.getPlasmaCoinAsync(deposit3.slot)
   const blocks = await bob.getBlockNumbersAsync(coin.depositBlockNum)
-
   const proofs = await bob.getCoinHistoryAsync(deposit3.slot, blocks)
-  t.equal(await charlie.verifyCoinHistoryAsync(deposit3.slot, proofs), true)
+  t.equal(await charlie.verifyCoinHistoryAsync(deposit3.slot, proofs), true, "Coin history verified")
   let charlieCoin = charlie.watchExit(deposit3.slot, coin.depositBlockNum)
 
-
-  await charlie.startExitAsync({
-    slot: deposit3.slot,
-    prevBlockNum: plasmaBlockNum1,
-    exitBlockNum: plasmaBlockNum2
-  })
+  await charlie.exit(deposit3.slot)
   charlie.stopWatching(charlieCoin)
 
   // Jump forward in time by 8 days
@@ -134,6 +131,14 @@ export async function runDemo(t: test.Test) {
   t.equal(balance.toNumber(), 1, 'charlie should have 1 token in cards contract')
 
   // Close the websocket, hacky :/
+  // @ts-ignore
+  authority.web3.currentProvider.connection.close()
+  // @ts-ignore
+  alice.web3.currentProvider.connection.close()
+  // @ts-ignore
+  bob.web3.currentProvider.connection.close()
+  // @ts-ignore
+  charlie.web3.currentProvider.connection.close()
   // @ts-ignore
   web3.currentProvider.connection.close()
 

--- a/loom_js_test/src/demo.ts
+++ b/loom_js_test/src/demo.ts
@@ -115,7 +115,7 @@ export async function runDemo(t: test.Test) {
   await authority.finalizeExitsAsync()
   // Charlie should now be able to withdraw the UTXO (plasma token) which contains ERC721 token #2
   // into his wallet.
-  await charlie.withdrawCoinAsync(deposit3.slot)
+  await charlie.withdrawAsync(deposit3.slot)
 
   balance = await cards.balanceOfAsync(alice.ethAddress)
   t.equal(balance.toNumber(), 2, 'alice should have 2 tokens in cards contract')

--- a/loom_js_test/src/demo.ts
+++ b/loom_js_test/src/demo.ts
@@ -96,23 +96,23 @@ export async function runDemo(t: test.Test) {
 
   // For alice's piece of mind, when transacting, she has to verify that her transaction was included and is not withheld _in limbo_.
   t.equal(
-    await alice.verifyInclusion(deposit2.slot, inclusionBlock),
+    await alice.verifyInclusionAsync(deposit2.slot, inclusionBlock),
     true,
     'alice verified tx is not in limbo'
   )
   t.equal(
-    await charlie.verifyInclusion(deposit2.slot, inclusionBlock),
+    await charlie.verifyInclusionAsync(deposit2.slot, inclusionBlock),
     true,
     'charlie verified tx is not in limbo'
   )
 
   t.equal(
-    await alice.verifyInclusion(deposit3.slot, inclusionBlock),
+    await alice.verifyInclusionAsync(deposit3.slot, inclusionBlock),
     true,
     'alice verified tx is not in limbo'
   )
   t.equal(
-    await bob.verifyInclusion(deposit3.slot, inclusionBlock),
+    await bob.verifyInclusionAsync(deposit3.slot, inclusionBlock),
     true,
     'bob verified tx is not in limbo'
   )

--- a/loom_js_test/src/demo.ts
+++ b/loom_js_test/src/demo.ts
@@ -16,10 +16,30 @@ export async function runDemo(t: test.Test) {
   const web3 = new Web3(new Web3.providers.WebsocketProvider(web3Endpoint))
   const { cards } = setupContracts(web3)
 
-  const authority = PlasmaUser.createUser(web3Endpoint, ADDRESSES.root_chain, dappchainEndpoint, ACCOUNTS.authority)
-  const alice = PlasmaUser.createUser(web3Endpoint, ADDRESSES.root_chain, dappchainEndpoint, ACCOUNTS.alice)
-  const bob = PlasmaUser.createUser(web3Endpoint, ADDRESSES.root_chain, dappchainEndpoint, ACCOUNTS.bob)
-  const charlie = PlasmaUser.createUser(web3Endpoint, ADDRESSES.root_chain, dappchainEndpoint, ACCOUNTS.charlie)
+  const authority = PlasmaUser.createUser(
+    web3Endpoint,
+    ADDRESSES.root_chain,
+    dappchainEndpoint,
+    ACCOUNTS.authority
+  )
+  const alice = PlasmaUser.createUser(
+    web3Endpoint,
+    ADDRESSES.root_chain,
+    dappchainEndpoint,
+    ACCOUNTS.alice
+  )
+  const bob = PlasmaUser.createUser(
+    web3Endpoint,
+    ADDRESSES.root_chain,
+    dappchainEndpoint,
+    ACCOUNTS.bob
+  )
+  const charlie = PlasmaUser.createUser(
+    web3Endpoint,
+    ADDRESSES.root_chain,
+    dappchainEndpoint,
+    ACCOUNTS.charlie
+  )
 
   await cards.registerAsync(alice.ethAddress)
   let balance = await cards.balanceOfAsync(alice.ethAddress)
@@ -70,17 +90,32 @@ export async function runDemo(t: test.Test) {
   await alice.transferAsync(deposit2.slot, charlie.ethAddress)
 
   let aliceCoins = await alice.getUserCoinsAsync()
-  t.ok(aliceCoins[0].slot.eq(deposits[0].slot), "Alice has correct coin")
+  t.ok(aliceCoins[0].slot.eq(deposits[0].slot), 'Alice has correct coin')
 
   const inclusionBlock = await authority.submitPlasmaBlockAsync()
 
-  // For alice's piece of mind, when transacting, she has to verify that her transaction was included and is not withheld _in limbo_. 
-  t.equal(await alice.verifyInclusion(deposit2.slot, inclusionBlock), true, "alice verified tx is not in limbo")
-  t.equal(await charlie.verifyInclusion(deposit2.slot, inclusionBlock), true, "charlie verified tx is not in limbo")
+  // For alice's piece of mind, when transacting, she has to verify that her transaction was included and is not withheld _in limbo_.
+  t.equal(
+    await alice.verifyInclusion(deposit2.slot, inclusionBlock),
+    true,
+    'alice verified tx is not in limbo'
+  )
+  t.equal(
+    await charlie.verifyInclusion(deposit2.slot, inclusionBlock),
+    true,
+    'charlie verified tx is not in limbo'
+  )
 
-  t.equal(await alice.verifyInclusion(deposit3.slot, inclusionBlock), true, "alice verified tx is not in limbo")
-  t.equal(await bob.verifyInclusion(deposit3.slot, inclusionBlock), true, "bob verified tx is not in limbo")
-
+  t.equal(
+    await alice.verifyInclusion(deposit3.slot, inclusionBlock),
+    true,
+    'alice verified tx is not in limbo'
+  )
+  t.equal(
+    await bob.verifyInclusion(deposit3.slot, inclusionBlock),
+    true,
+    'bob verified tx is not in limbo'
+  )
 
   // Add an empty block in between (for proof of exclusion)
   await authority.submitPlasmaBlockAsync()
@@ -90,11 +125,11 @@ export async function runDemo(t: test.Test) {
   await charlie.refreshAsync()
 
   // The legit operator will allow access to these variables as usual. The non-legit operator won't and as a result `getUserCoinsAsync` is empty
-  if (bob.contractName !== 'hostileoperator')  {
+  if (bob.contractName !== 'hostileoperator') {
     let bobCoins = await bob.getUserCoinsAsync()
-    t.ok(bobCoins[0].slot.eq(deposit3.slot), "Bob has correct coin")
+    t.ok(bobCoins[0].slot.eq(deposit3.slot), 'Bob has correct coin')
     let charlieCoins = await charlie.getUserCoinsAsync()
-    t.ok(charlieCoins[0].slot.eq(deposit2.slot), "Charlie has correct coin")
+    t.ok(charlieCoins[0].slot.eq(deposit2.slot), 'Charlie has correct coin')
   }
 
   await bob.refreshAsync()
@@ -109,7 +144,7 @@ export async function runDemo(t: test.Test) {
   await charlie.refreshAsync()
 
   const coin = await charlie.getPlasmaCoinAsync(deposit3.slot)
-  t.equal(await charlie.checkHistoryAsync(coin), true, "Coin history verified")
+  t.equal(await charlie.checkHistoryAsync(coin), true, 'Coin history verified')
   let charlieCoin = charlie.watchExit(deposit3.slot, coin.depositBlockNum)
 
   await charlie.exitAsync(deposit3.slot)

--- a/loom_js_test/src/respond-challenge-before-demo.ts
+++ b/loom_js_test/src/respond-challenge-before-demo.ts
@@ -2,34 +2,21 @@ import test from 'tape'
 import BN from 'bn.js'
 import Web3 from 'web3'
 import {
-  IPlasmaDeposit,
-  marshalDepositEvent,
-  IPlasmaChallenge,
-  marshalChallengeEvent
+  createUser
 } from 'loom-js'
 
 import { increaseTime, getEthBalanceAtAddress } from './ganache-helpers'
-import { sleep, createTestEntity, ADDRESSES, ACCOUNTS } from './config'
-import { EthCardsContract } from './cards-contract'
-
-// Alice registers and has 5 coins, and she deposits 3 of them.
-const ALICE_INITIAL_COINS = 5
-const ALICE_DEPOSITED_COINS = 3
-const COINS = [1, 2, 3]
-
-// All the contracts are expected to have been deployed to Ganache when this function is called.
-function setupContracts(web3: Web3): { cards: EthCardsContract } {
-  const abi = require('./contracts/cards-abi.json')
-  const cards = new EthCardsContract(new web3.eth.Contract(abi, ADDRESSES.token_contract))
-  return { cards }
-}
+import { sleep, ADDRESSES, ACCOUNTS, setupContracts } from './config'
 
 export async function runRespondChallengeBeforeDemo(t: test.Test) {
-  const web3 = new Web3(new Web3.providers.WebsocketProvider('ws://localhost:8545'))
+  const web3Endpoint = 'ws://127.0.0.1:8545'
+  const dappchainEndpoint = 'http://localhost:46658'
+  const web3 = new Web3(new Web3.providers.WebsocketProvider(web3Endpoint))
   const { cards } = setupContracts(web3)
-  const authority = createTestEntity(web3, ACCOUNTS.authority)
-  const dan = createTestEntity(web3, ACCOUNTS.dan)
-  const trudy = createTestEntity(web3, ACCOUNTS.trudy)
+
+  const authority = createUser(web3Endpoint, ADDRESSES.root_chain, dappchainEndpoint, ACCOUNTS.authority)
+  const dan  = createUser(web3Endpoint, ADDRESSES.root_chain, dappchainEndpoint, ACCOUNTS.dan )
+  const trudy = createUser(web3Endpoint, ADDRESSES.root_chain, dappchainEndpoint, ACCOUNTS.trudy)
 
   // Give Trudy 5 tokens
   await cards.registerAsync(trudy.ethAddress)
@@ -40,12 +27,7 @@ export async function runRespondChallengeBeforeDemo(t: test.Test) {
   // Trudy deposits a coin
   await cards.depositToPlasmaAsync({ tokenId: 21, from: trudy.ethAddress })
 
-  const depositEvents: any[] = await authority.plasmaCashContract.getPastEvents('Deposit', {
-    fromBlock: startBlockNum
-  })
-  const deposits = depositEvents.map<IPlasmaDeposit>(event =>
-    marshalDepositEvent(event.returnValues)
-  )
+  const deposits = await trudy.deposits()
   t.equal(deposits.length, 1, 'All deposit events accounted for')
 
   await sleep(8000)
@@ -56,22 +38,13 @@ export async function runRespondChallengeBeforeDemo(t: test.Test) {
 
   // Trudy sends her coin to Dan
   const coin = await trudy.getPlasmaCoinAsync(deposit1Slot)
-  await trudy.transferTokenAsync({
-    slot: deposit1Slot,
-    prevBlockNum: coin.depositBlockNum,
-    denomination: 1,
-    newOwner: dan.ethAddress
-  })
+  await trudy.transfer(deposit1Slot, dan.ethAddress)
 
   // Operator includes it
-  const trudyToDanBlock = await authority.submitPlasmaBlockAsync()
+  await authority.submitPlasmaBlockAsync()
 
   // Dan exits the coin received by Trudy
-  await dan.startExitAsync({
-    slot: deposit1Slot,
-    prevBlockNum: coin.depositBlockNum,
-    exitBlockNum: trudyToDanBlock
-  })
+  await dan.exit(deposit1Slot)
   const danExit = dan.watchChallenge(deposit1Slot, coin.depositBlockNum)
 
   // Trudy tries to challengeBefore Dan's exit
@@ -101,8 +74,16 @@ export async function runRespondChallengeBeforeDemo(t: test.Test) {
   // 1 in this demo and 1 in a previous one.
   t.equal(danTokensEnd.toNumber(), 7, 'END: Dan has correct number of tokens')
 
+
   // Close the websocket, hacky :/
   // @ts-ignore
   web3.currentProvider.connection.close()
+  // @ts-ignore
+  authority.web3.currentProvider.connection.close()
+  // @ts-ignore
+  dan.web3.currentProvider.connection.close()
+  // @ts-ignore
+  trudy.web3.currentProvider.connection.close()
+
   t.end()
 }

--- a/loom_js_test/src/respond-challenge-before-demo.ts
+++ b/loom_js_test/src/respond-challenge-before-demo.ts
@@ -1,9 +1,7 @@
 import test from 'tape'
 import BN from 'bn.js'
 import Web3 from 'web3'
-import {
-  PlasmaUser
-} from 'loom-js'
+import { PlasmaUser } from 'loom-js'
 
 import { increaseTime, getEthBalanceAtAddress } from './ganache-helpers'
 import { sleep, ADDRESSES, ACCOUNTS, setupContracts } from './config'
@@ -14,9 +12,24 @@ export async function runRespondChallengeBeforeDemo(t: test.Test) {
   const web3 = new Web3(new Web3.providers.WebsocketProvider(web3Endpoint))
   const { cards } = setupContracts(web3)
 
-  const authority = PlasmaUser.createUser(web3Endpoint, ADDRESSES.root_chain, dappchainEndpoint, ACCOUNTS.authority)
-  const dan  = PlasmaUser.createUser(web3Endpoint, ADDRESSES.root_chain, dappchainEndpoint, ACCOUNTS.dan )
-  const trudy = PlasmaUser.createUser(web3Endpoint, ADDRESSES.root_chain, dappchainEndpoint, ACCOUNTS.trudy)
+  const authority = PlasmaUser.createUser(
+    web3Endpoint,
+    ADDRESSES.root_chain,
+    dappchainEndpoint,
+    ACCOUNTS.authority
+  )
+  const dan = PlasmaUser.createUser(
+    web3Endpoint,
+    ADDRESSES.root_chain,
+    dappchainEndpoint,
+    ACCOUNTS.dan
+  )
+  const trudy = PlasmaUser.createUser(
+    web3Endpoint,
+    ADDRESSES.root_chain,
+    dappchainEndpoint,
+    ACCOUNTS.trudy
+  )
 
   // Give Trudy 5 tokens
   await cards.registerAsync(trudy.ethAddress)
@@ -73,7 +86,6 @@ export async function runRespondChallengeBeforeDemo(t: test.Test) {
   // Dan had initially 5 from when he registered and he received 2 coins
   // 1 in this demo and 1 in a previous one.
   t.equal(danTokensEnd.toNumber(), 7, 'END: Dan has correct number of tokens')
-
 
   // Close the websocket, hacky :/
   // @ts-ignore

--- a/loom_js_test/src/respond-challenge-before-demo.ts
+++ b/loom_js_test/src/respond-challenge-before-demo.ts
@@ -62,7 +62,7 @@ export async function runRespondChallengeBeforeDemo(t: test.Test) {
   // Now that the exit has been finalized, stop watching challenges
   dan.stopWatching(danExit)
 
-  await dan.withdrawCoinAsync(deposit1Slot)
+  await dan.withdrawAsync(deposit1Slot)
 
   const danBalanceBefore = await getEthBalanceAtAddress(web3, dan.ethAddress)
   await dan.withdrawBondsAsync()

--- a/loom_js_test/src/test-honest-operator.ts
+++ b/loom_js_test/src/test-honest-operator.ts
@@ -2,7 +2,7 @@ import test from 'tape'
 
 import { runDemo } from './demo'
 import { runChallengeAfterDemo } from './challenge-after-demo'
-import { PlasmaUser } from 'loom-js';
+import { PlasmaUser } from 'loom-js'
 
 // TODO: Redeploy the Solidity contracts before each demo so the demos don't share any state.
 

--- a/loom_js_test/src/test-honest-operator.ts
+++ b/loom_js_test/src/test-honest-operator.ts
@@ -1,11 +1,9 @@
 import test from 'tape'
 
-import { enableHostilePlasmaCashOperator } from './config'
 import { runDemo } from './demo'
 import { runChallengeAfterDemo } from './challenge-after-demo'
 
 // TODO: Redeploy the Solidity contracts before each demo so the demos don't share any state.
 
-enableHostilePlasmaCashOperator(false)
 test('Plasma Cash with ERC721 Demo', runDemo)
 test('Plasma Cash Challenge After Demo', runChallengeAfterDemo)

--- a/loom_js_test/src/test-honest-operator.ts
+++ b/loom_js_test/src/test-honest-operator.ts
@@ -2,8 +2,10 @@ import test from 'tape'
 
 import { runDemo } from './demo'
 import { runChallengeAfterDemo } from './challenge-after-demo'
+import { PlasmaUser } from 'loom-js';
 
 // TODO: Redeploy the Solidity contracts before each demo so the demos don't share any state.
 
+PlasmaUser.contractName = 'plasmacash'
 test('Plasma Cash with ERC721 Demo', runDemo)
 test('Plasma Cash Challenge After Demo', runChallengeAfterDemo)

--- a/loom_js_test/src/test-hostile-operator.ts
+++ b/loom_js_test/src/test-hostile-operator.ts
@@ -5,11 +5,11 @@ import { runChallengeAfterDemo } from './challenge-after-demo'
 import { runChallengeBetweenDemo } from './challenge-between-demo'
 import { runChallengeBeforeDemo } from './challenge-before-demo'
 import { runRespondChallengeBeforeDemo } from './respond-challenge-before-demo'
-import { setContractName } from 'loom-js';
+import { PlasmaUser } from 'loom-js';
 
 // TODO: Redeploy the Solidity contracts before each demo so the demos don't share any state.
 
-setContractName('hostileoperator')
+PlasmaUser.contractName = 'hostileoperator'
 test('Plasma Cash with ERC721 Demo', runDemo)
 test('Plasma Cash Challenge After Demo', runChallengeAfterDemo)
 test('Plasma Cash Challenge Between Demo', runChallengeBetweenDemo)

--- a/loom_js_test/src/test-hostile-operator.ts
+++ b/loom_js_test/src/test-hostile-operator.ts
@@ -5,7 +5,7 @@ import { runChallengeAfterDemo } from './challenge-after-demo'
 import { runChallengeBetweenDemo } from './challenge-between-demo'
 import { runChallengeBeforeDemo } from './challenge-before-demo'
 import { runRespondChallengeBeforeDemo } from './respond-challenge-before-demo'
-import { PlasmaUser } from 'loom-js';
+import { PlasmaUser } from 'loom-js'
 
 // TODO: Redeploy the Solidity contracts before each demo so the demos don't share any state.
 

--- a/loom_js_test/src/test-hostile-operator.ts
+++ b/loom_js_test/src/test-hostile-operator.ts
@@ -1,15 +1,15 @@
 import test from 'tape'
 
-import { enableHostilePlasmaCashOperator } from './config'
 import { runDemo } from './demo'
 import { runChallengeAfterDemo } from './challenge-after-demo'
 import { runChallengeBetweenDemo } from './challenge-between-demo'
 import { runChallengeBeforeDemo } from './challenge-before-demo'
 import { runRespondChallengeBeforeDemo } from './respond-challenge-before-demo'
+import { setContractName } from 'loom-js';
 
 // TODO: Redeploy the Solidity contracts before each demo so the demos don't share any state.
 
-enableHostilePlasmaCashOperator(true)
+setContractName('hostileoperator')
 test('Plasma Cash with ERC721 Demo', runDemo)
 test('Plasma Cash Challenge After Demo', runChallengeAfterDemo)
 test('Plasma Cash Challenge Between Demo', runChallengeBetweenDemo)

--- a/loom_js_test/yarn.lock
+++ b/loom_js_test/yarn.lock
@@ -4448,9 +4448,9 @@ long@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/long/-/long-3.2.0.tgz#d821b7138ca1cb581c172990ef14db200b5c474b"
 
-"loom-js@git+https://github.com/loomnetwork/loom-js.git#build-files":
-  version "1.25.0"
-  resolved "git+https://github.com/loomnetwork/loom-js.git#9add9c59d81572ba6215beb9c7a0fa4b8686ae13"
+"loom-js@https://github.com/loomnetwork/loom-js#build-files":
+  version "1.26.0"
+  resolved "https://github.com/loomnetwork/loom-js#0fea029ba8518ba0f17659d0daf1b770c4592dcb"
   dependencies:
     axios "^0.18.0"
     bn.js "^4.11.8"

--- a/loom_js_test/yarn.lock
+++ b/loom_js_test/yarn.lock
@@ -4448,9 +4448,9 @@ long@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/long/-/long-3.2.0.tgz#d821b7138ca1cb581c172990ef14db200b5c474b"
 
-"loom-js@https://github.com/loomnetwork/loom-js#build-files":
-  version "1.26.0"
-  resolved "https://github.com/loomnetwork/loom-js#0fea029ba8518ba0f17659d0daf1b770c4592dcb"
+loom-js@^1.27.0:
+  version "1.27.0"
+  resolved "https://registry.yarnpkg.com/loom-js/-/loom-js-1.27.0.tgz#a0059233bd77b83bdf80386c4bf95f7c09757510"
   dependencies:
     axios "^0.18.0"
     bn.js "^4.11.8"


### PR DESCRIPTION
Simplifies tests by using the wrapper `User` class.
The hostile contract does not perform certain operations that are there for security (in order to defraud users). The `loom-js` client expects honest state, and thus the cheaters need to make direct "lower" level calls to make the disallowed operations.

Depends on https://github.com/loomnetwork/loom-js/pull/115/