### PR TITLE
Fix a bug in assertRevert

### DIFF
--- a/server/test/helpers/assertRevert.js
+++ b/server/test/helpers/assertRevert.js
@@ -1,7 +1,7 @@
 export default async promise => {
   try {
     await promise;
-    assert.fail('Expected revert not received');
+    assert.fail('Expected REVERT not received');
   } catch (error) {
     const revertFound = error.message.search('revert') >= 0;
     assert(revertFound, `Expected "revert", got ${error} instead`);


### PR DESCRIPTION
Exception thrown by `assert.fail('Expected revert not received')` is mishandled because the error message also contains the word `revert`.